### PR TITLE
Update Discord voice timeout

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -99,10 +99,10 @@ func (s *StreamingSession) readNext() error {
 		return err
 	}
 
-	// Timeout after 100ms (Maybe this needs to be changed?)
-	timeOut := time.After(time.Second)
+	// Timeout after 5 seconds
+	timeOut := time.After(5 * time.Second)
 
-	// This will attempt to send on the channel before the timeout, which is 1s
+	// This will attempt to send on the channel before the timeout, which is 5s
 	select {
 	case <-timeOut:
 		return ErrVoiceConnClosed


### PR DESCRIPTION
From my own testing, I've come to the conclusion that the default timeout is too short - the bot would stop playing music if the voice connection got lost for a moment or if it was moved to another channel. I think 5 seconds is plenty of time for it to reconnect to voice if it disconnects.

Thanks for this great project.